### PR TITLE
Update to dockerfile to be able to install chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN  apt-get update \
      && apt-get install -y wget --no-install-recommends \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
      && wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
-     && sudo dpkg -i gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
+     && dpkg -i gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
      && wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/libgcc-s1_10-20200411-0ubuntu1_amd64.deb \
-     && sudo dpkg -i libgcc-s1_10-20200411-0ubuntu1_amd64.deb \
+     && dpkg -i libgcc-s1_10-20200411-0ubuntu1_amd64.deb \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
      && apt-get update \
      && apt-get install -y google-chrome-stable --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN  apt-get update \
      # make the bundled version of Chromium that Puppeteer installs work.
      && apt-get install -y wget --no-install-recommends \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+     && wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
+     && sudo dpkg -i gcc-10-base_10-20200411-0ubuntu1_amd64.deb \
+     && wget https://mirrors.edge.kernel.org/ubuntu/pool/main/g/gcc-10/libgcc-s1_10-20200411-0ubuntu1_amd64.deb \
+     && sudo dpkg -i libgcc-s1_10-20200411-0ubuntu1_amd64.deb \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
      && apt-get update \
      && apt-get install -y google-chrome-stable --no-install-recommends \


### PR DESCRIPTION
https://askubuntu.com/questions/1524103/google-chrome-stable-depends-libgcc-s1-4-2-but-it-is-not-installable